### PR TITLE
Update berksfile, metadata, and remove gemfile

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,2 +1,2 @@
-source "https://supermarket.getchef.com"
+source "https://supermarket.chef.io"
 metadata

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,0 @@
-source 'https://rubygems.org'
-
-gem 'berkshelf'

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,14 +6,5 @@ description      'Installs/Configures artifactory'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.3.4'
 
-recipe 'artifactory::default', 'Installs Artifactory Pro.'
-recipe 'artifactory::apache-proxy', 'Setup Apache reverse proxy in front of Artifactory.'
-recipe 'artifactory::configuration', 'Adds license to artifactory pro'
-
 depends          'java'
 depends          'apache2'
-
-supports 'ubuntu'
-supports 'debian'
-supports 'rhel'
-supports 'centos'


### PR DESCRIPTION
During an attempt to upload this cookbook to Chef Server 12.11.1 using ChefDK 1.1.16 berks crashed and was unable to upload. After completing these changes berks successfully was able to upload to the Chef Server.

- The public supermarket url has changed from supermarket.getchef.com to supermarket.chef.io.
- Currently the gemfile is not longer needed because the ChefDK currently contains the most recent version of berkshelf.
- Community discussion recommends not using the supports tag in the metadata or the recipe tag in the metadata. Not sure if this is the reason for the crash.